### PR TITLE
change elasticsearch_host to elasticsearchhost to avoid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ MAINTAINER Ivan Krizsan, https://github.com/krizsan
 ENV SET_CONTAINER_TIMEZONE false
 # Default container timezone as found under the directory /usr/share/zoneinfo/.
 ENV CONTAINER_TIMEZONE Europe/Stockholm
-# URL from which to download Elastalert.
-ENV ELASTALERT_URL https://github.com/Yelp/elastalert/archive/master.zip
+# URL from which to download Elastalert. Temporary point to ES5 host
+#ENV ELASTALERT_URL https://github.com/Yelp/elastalert/archive/master.zip
+ENV ELASTALERT_URL https://github.com/suqld/elastalert/archive/support_es5.zip
 # Directory holding configuration for Elastalert and Supervisor.
 ENV CONFIG_DIR /opt/config
 # Elastalert rules directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,8 @@ MAINTAINER Ivan Krizsan, https://github.com/krizsan
 ENV SET_CONTAINER_TIMEZONE false
 # Default container timezone as found under the directory /usr/share/zoneinfo/.
 ENV CONTAINER_TIMEZONE Europe/Stockholm
-# URL from which to download Elastalert. Temporary point to ES5 host
-#ENV ELASTALERT_URL https://github.com/Yelp/elastalert/archive/master.zip
-ENV ELASTALERT_URL https://github.com/suqld/elastalert/archive/support_es5.zip
+# URL from which to download Elastalert.
+ENV ELASTALERT_URL https://github.com/Yelp/elastalert/archive/master.zip
 # Directory holding configuration for Elastalert and Supervisor.
 ENV CONFIG_DIR /opt/config
 # Elastalert rules directory.

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ ENV ELASTALERT_HOME /opt/${ELASTALERT_DIRECTORY_NAME}
 # Supervisor configuration file for Elastalert.
 ENV ELASTALERT_SUPERVISOR_CONF ${CONFIG_DIR}/elastalert_supervisord.conf
 # Alias, DNS or IP of Elasticsearch host to be queried by Elastalert. Set in default Elasticsearch configuration file.
-ENV ELASTICSEARCH_HOST elasticsearch_host
+ENV ELASTICSEARCH_HOST elasticsearchhost
 # Port on above Elasticsearch host. Set in default Elasticsearch configuration file.
 ENV ELASTICSEARCH_PORT 9200
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Elastalert Docker Image
 Docker image with Elastalert on Alpine Linux.
 
-Requires a link to a Docker container running Elasticsearch using the "elasticsearch_host" alias.
+Requires a link to a Docker container running Elasticsearch using the "elasticsearchhost" alias.
 Assumes the use of port 9200 when communicating with Elasticsearch.<br/>
 In order for the time of the container to be synchronized (ntpd), it must be run with the SYS_TIME capability.
 In addition you may want to add the SYS_NICE capability, in order for ntpd to be able to modify its priority.


### PR DESCRIPTION
change elasticsearch_host to elasticsearchhost to avoid  
requests.exceptions.InvalidURL: URL has an invalid label issue when creating index on ES