### PR TITLE
Enable no_proxy setting to work with wget for internal check of elast…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY ./start-elastalert.sh /opt/
 # Install software required for Elastalert and NTP for time synchronization.
 RUN apk update && \
     apk upgrade && \
-    apk add ca-certificates openssl-dev openssl libffi-dev python2 python2-dev py2-pip py2-yaml gcc musl-dev tzdata openntpd && \
+    apk add ca-certificates openssl-dev openssl libffi-dev python2 python2-dev py2-pip py2-yaml gcc musl-dev tzdata openntpd wget && \
 # Download and unpack Elastalert.
     wget -O elastalert.zip "${ELASTALERT_URL}" && \
     unzip elastalert.zip && \


### PR DESCRIPTION
The default `wget` in alpine does not support the `NO_PROXY` variable - this is needed in corporate environments with outbound proxies.

Installing regular `wget` fixes this.

The code area this affects is in the **start-elastalert.sh** file.
See below for the code section.
The bug causes the "Waiting for Elasticsearch..." to loop forever as it cannot contact the elasticsearch server.

```
while ! wget -q -T 3 -O - "${WGET_SCHEMA}${WGET_AUTH}${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}" 2>/dev/null
do
	echo "Waiting for Elasticsearch..."
	sleep 1
done
```