### PR TITLE
Improve image and configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM alpine
 
-MAINTAINER Ivan Krizsan, https://github.com/krizsan
+LABEL maintainer="Ivan Krizsan, https://github.com/krizsan"
 
 # Set this environment variable to true to set timezone on container start.
 ENV SET_CONTAINER_TIMEZONE false
@@ -19,10 +19,8 @@ ENV RULES_DIRECTORY /opt/rules
 ENV ELASTALERT_CONFIG ${CONFIG_DIR}/elastalert_config.yaml
 # Directory to which Elastalert and Supervisor logs are written.
 ENV LOG_DIR /opt/logs
-# Elastalert home directory name.
-ENV ELASTALERT_DIRECTORY_NAME elastalert
 # Elastalert home directory full path.
-ENV ELASTALERT_HOME /opt/${ELASTALERT_DIRECTORY_NAME}
+ENV ELASTALERT_HOME /opt/elastalert
 # Supervisor configuration file for Elastalert.
 ENV ELASTALERT_SUPERVISOR_CONF ${CONFIG_DIR}/elastalert_supervisord.conf
 # Alias, DNS or IP of Elasticsearch host to be queried by Elastalert. Set in default Elasticsearch configuration file.
@@ -33,11 +31,10 @@ ENV ELASTICSEARCH_PORT 9200
 ENV ELASTICSEARCH_TLS false
 # Verify TLS
 ENV ELASTICSEARCH_TLS_VERIFY true
+# ElastAlert writeback index
+ENV ELASTALERT_INDEX elastalert_status
 
 WORKDIR /opt
-
-# Copy the script used to launch the Elastalert when a container is started.
-COPY ./start-elastalert.sh /opt/
 
 # Install software required for Elastalert and NTP for time synchronization.
 RUN apk update && \
@@ -47,7 +44,7 @@ RUN apk update && \
     wget -O elastalert.zip "${ELASTALERT_URL}" && \
     unzip elastalert.zip && \
     rm elastalert.zip && \
-    mv e* "${ELASTALERT_DIRECTORY_NAME}"
+    mv e* "${ELASTALERT_HOME}"
 
 WORKDIR "${ELASTALERT_HOME}"
 
@@ -60,37 +57,11 @@ RUN python setup.py install && \
 # Install Supervisor.
     easy_install supervisor && \
 
-# Make the start-script executable.
-    chmod +x /opt/start-elastalert.sh && \
-
 # Create directories. The /var/empty directory is used by openntpd.
     mkdir -p "${CONFIG_DIR}" && \
     mkdir -p "${RULES_DIRECTORY}" && \
     mkdir -p "${LOG_DIR}" && \
     mkdir -p /var/empty && \
-
-# Copy default configuration files to configuration directory.
-    cp "${ELASTALERT_HOME}/config.yaml.example" "${ELASTALERT_CONFIG}" && \
-    cp "${ELASTALERT_HOME}/supervisord.conf.example" "${ELASTALERT_SUPERVISOR_CONF}" && \
-
-# Elastalert configuration:
-    # Set the rule directory in the Elastalert config file to external rules directory.
-    sed -i -e"s|rules_folder: [[:print:]]*|rules_folder: ${RULES_DIRECTORY}|g" "${ELASTALERT_CONFIG}" && \
-    # Set the Elasticsearch host that Elastalert is to query.
-    sed -i -e"s|es_host: [[:print:]]*|es_host: ${ELASTICSEARCH_HOST}|g" "${ELASTALERT_CONFIG}" && \
-    # Set the port used by Elasticsearch at the above address.
-    sed -i -e"s|es_port: [0-9]*|es_port: ${ELASTICSEARCH_PORT}|g" "${ELASTALERT_CONFIG}" && \
-
-# Elastalert Supervisor configuration:
-    # Redirect Supervisor log output to a file in the designated logs directory.
-    sed -i -e"s|logfile=.*log|logfile=${LOG_DIR}/elastalert_supervisord.log|g" "${ELASTALERT_SUPERVISOR_CONF}" && \
-    # Redirect Supervisor stderr output to a file in the designated logs directory.
-    sed -i -e"s|stderr_logfile=.*log|stderr_logfile=${LOG_DIR}/elastalert_stderr.log|g" "${ELASTALERT_SUPERVISOR_CONF}" && \
-    # Modify the start-command.
-    sed -i -e"s|python elastalert.py|python -m elastalert.elastalert --config ${ELASTALERT_CONFIG}|g" "${ELASTALERT_SUPERVISOR_CONF}" && \
-
-# Copy the Elastalert configuration file to Elastalert home directory to be used when creating index first time an Elastalert container is launched.
-    cp "${ELASTALERT_CONFIG}" "${ELASTALERT_HOME}/config.yaml" && \
 
 # Clean up.
     apk del python2-dev && \
@@ -98,10 +69,12 @@ RUN python setup.py install && \
     apk del gcc && \
     apk del openssl-dev && \
     apk del libffi-dev && \
-    rm -rf /var/cache/apk/* && \
+    rm -rf /var/cache/apk/*
 
-# Add Elastalert to Supervisord.
-    supervisord -c "${ELASTALERT_SUPERVISOR_CONF}"
+# Copy the script used to launch the Elastalert when a container is started.
+COPY ./start-elastalert.sh /opt/
+# Make the start-script executable.
+RUN chmod +x /opt/start-elastalert.sh
 
 # Define mount points.
 VOLUME [ "${CONFIG_DIR}", "${RULES_DIRECTORY}", "${LOG_DIR}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ FROM alpine
 
 LABEL maintainer="Ivan Krizsan, https://github.com/krizsan"
 
-# Set this environment variable to true to set timezone on container start.
-ENV SET_CONTAINER_TIMEZONE false
+# Set this environment variable to True to set timezone on container start.
+ENV SET_CONTAINER_TIMEZONE False
 # Default container timezone as found under the directory /usr/share/zoneinfo/.
 ENV CONTAINER_TIMEZONE Europe/Stockholm
 # URL from which to download Elastalert.
@@ -27,10 +27,10 @@ ENV ELASTALERT_SUPERVISOR_CONF ${CONFIG_DIR}/elastalert_supervisord.conf
 ENV ELASTICSEARCH_HOST elasticsearchhost
 # Port on above Elasticsearch host. Set in default Elasticsearch configuration file.
 ENV ELASTICSEARCH_PORT 9200
-# Use TLS to connect to Elasticsearch (true or false)
-ENV ELASTICSEARCH_TLS false
+# Use TLS to connect to Elasticsearch (True or False)
+ENV ELASTICSEARCH_TLS False
 # Verify TLS
-ENV ELASTICSEARCH_TLS_VERIFY true
+ENV ELASTICSEARCH_TLS_VERIFY True
 # ElastAlert writeback index
 ENV ELASTALERT_INDEX elastalert_status
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ es_password: changeme
 
 # Environment
 
-- SET_CONTAINER_TIMEZONE - Set to "true" (without quotes) to set the timezone when starting a container. Default is `false`.
+- SET_CONTAINER_TIMEZONE - Set to "True" (without quotes) to set the timezone when starting a container. Default is `False`.
 - CONTAINER_TIMEZONE - Timezone to use in container. Default is `Europe/Stockholm`.
 - ELASTICSEARCH_HOST - IP or hostname for your Elasticsearch host. Defaults to `elasticsearchhost`.
 - ELASTICSEARCH_PORT - Port for your Elasticsearch host. Defaults to `9200`.
 - ELASTICSEARCH_USER - Name of user to log into Ealsticsearch with. Leave undefined for no authentication.
 - ELASTICSEARCH_PASSWORD - Password to log into Elasticsearch with. Leave undefined for no authentication.
-- ELASTICSEARCH_TLS - Use HTTPS when connecting to Elasticsearch (true/false). Default is `false`.
-- ELASTICSEARCH_TLS_VERIFY - Verify server (Elasticsearch) certificate (true/false). Default is `false`.
+- ELASTICSEARCH_TLS - Use HTTPS when connecting to Elasticsearch (True/False). Default is `False`.
+- ELASTICSEARCH_TLS_VERIFY - Verify server (Elasticsearch) certificate (True/False). Default is `False`.
 - ELASTALERT_INDEX - Name of Elastalert writeback index in Elasticseach. Defaults to `elastalert_status`.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,33 @@
 # Elastalert Docker Image
+
 Docker image with Elastalert on Alpine Linux.
 
-Requires a link to a Docker container running Elasticsearch using the "elasticsearchhost" alias.
-Assumes the use of port 9200 when communicating with Elasticsearch.<br/>
+Assumes the use of port 9200 when communicating with Elasticsearch.
 In order for the time of the container to be synchronized (ntpd), it must be run with the SYS_TIME capability.
 In addition you may want to add the SYS_NICE capability, in order for ntpd to be able to modify its priority.
 
 If Elasticsearch requires authentication, then the two environment variables listed below must contain user and password.
-In addition, the Elastalert configuration file must also contain login credentials, like in this example:
+In addition, if you mount the Elastalert configuration file you must add login credentials, like in this example:
 ```
 es_username: elastic
 es_password: changeme
 ```
 
 # Volumes
+
 - /opt/logs       - Elastalert and Supervisord logs will be written to this directory.
 - /opt/config     - Elastalert (elastalert_config.yaml) and Supervisord (elastalert_supervisord.conf) configuration files.
-- /opt/rules      - Contains Elastalert rules.<br/>
+- /opt/rules      - Contains Elastalert rules.
+
 
 # Environment
-- SET_CONTAINER_TIMEZONE - Set to "true" (without quotes) to set the timezone when starting a container. Default is false.
-- CONTAINER_TIMEZONE - Timezone to use in container. Default is Europe/Stockholm.
+
+- SET_CONTAINER_TIMEZONE - Set to "true" (without quotes) to set the timezone when starting a container. Default is `false`.
+- CONTAINER_TIMEZONE - Timezone to use in container. Default is `Europe/Stockholm`.
+- ELASTICSEARCH_HOST - IP or hostname for your Elasticsearch host. Defaults to `elasticsearchhost`.
+- ELASTICSEARCH_PORT - Port for your Elasticsearch host. Defaults to `9200`.
 - ELASTICSEARCH_USER - Name of user to log into Ealsticsearch with. Leave undefined for no authentication.
 - ELASTICSEARCH_PASSWORD - Password to log into Elasticsearch with. Leave undefined for no authentication.
-- ELASTICSEARCH_TLS - Use HTTPS when connecting to Elasticsearch (true/false). Default is false.
-- ELASTICSEARCH_TLS_VERIFY - Verify server (Elasticsearch) certificate (true/false). Default is false.
+- ELASTICSEARCH_TLS - Use HTTPS when connecting to Elasticsearch (true/false). Default is `false`.
+- ELASTICSEARCH_TLS_VERIFY - Verify server (Elasticsearch) certificate (true/false). Default is `false`.
+- ELASTALERT_INDEX - Name of Elastalert writeback index in Elasticseach. Defaults to `elastalert_status`.

--- a/start-elastalert.sh
+++ b/start-elastalert.sh
@@ -43,9 +43,13 @@ if [ ! -f ${ELASTALERT_CONFIG} ]; then
     # Set the port used by Elasticsearch at the above address.
     sed -i -e"s|es_port: [0-9]*|es_port: ${ELASTICSEARCH_PORT}|g" "${ELASTALERT_CONFIG}"
     # Set the user name used to authenticate with Elasticsearch.
-    sed -i -e"s|#es_username: [[:print:]]*|es_username: ${ELASTICSEARCH_USER}|g" "${ELASTALERT_CONFIG}"
+    if [ -n "${ELASTICSEARCH_USER}" ]; then
+        sed -i -e"s|#es_username: [[:print:]]*|es_username: ${ELASTICSEARCH_USER}|g" "${ELASTALERT_CONFIG}"
+    fi
     # Set the password used to authenticate with Elasticsearch.
-    sed -i -e"s|#es_password: [[:print:]]*|es_password: ${ELASTICSEARCH_PASSWORD}|g" "${ELASTALERT_CONFIG}"
+    if [ -n "${ELASTICSEARCH_PASSWORD}" ]; then
+        sed -i -e"s|#es_password: [[:print:]]*|es_password: ${ELASTICSEARCH_PASSWORD}|g" "${ELASTALERT_CONFIG}"
+    fi
     # Set the writeback index used with elastalert.
     sed -i -e"s|writeback_index: [[:print:]]*|writeback_index: ${ELASTALERT_INDEX}|g" "${ELASTALERT_CONFIG}"
 fi

--- a/start-elastalert.sh
+++ b/start-elastalert.sh
@@ -2,28 +2,29 @@
 
 set -e
 
+# Set schema and elastalert options
 case "${ELASTICSEARCH_TLS}:${ELASTICSEARCH_TLS_VERIFY}" in
-  true:true)
-    WGET_SCHEMA='https://'
-    CREATE_EA_OPTIONS='--ssl --verify-certs'
-  ;;
-  true:false)
-    WGET_SCHEMA='https://'
-    CREATE_EA_OPTIONS='--ssl --no-verify-certs'
-  ;;
-  *)
-    WGET_SCHEMA='http://'
-    CREATE_EA_OPTIONS='--no-ssl'
-  ;;
+    true:true)
+        WGET_SCHEMA='https://'
+        CREATE_EA_OPTIONS='--ssl --verify-certs'
+    ;;
+    true:false)
+        WGET_SCHEMA='https://'
+        CREATE_EA_OPTIONS='--ssl --no-verify-certs'
+    ;;
+    *)
+        WGET_SCHEMA='http://'
+        CREATE_EA_OPTIONS='--no-ssl'
+    ;;
 esac
 
 # Set the timezone.
 if [ "$SET_CONTAINER_TIMEZONE" = "true" ]; then
-        cp /usr/share/zoneinfo/${CONTAINER_TIMEZONE} /etc/localtime && \
-	echo "${CONTAINER_TIMEZONE}" >  /etc/timezone && \
-	echo "Container timezone set to: $CONTAINER_TIMEZONE"
+    cp /usr/share/zoneinfo/${CONTAINER_TIMEZONE} /etc/localtime && \
+    echo "${CONTAINER_TIMEZONE}" >  /etc/timezone && \
+    echo "Container timezone set to: $CONTAINER_TIMEZONE"
 else
-	echo "Container timezone not modified"
+    echo "Container timezone not modified"
 fi
 
 # Force immediate synchronisation of the time and start the time-synchronization service.
@@ -31,24 +32,61 @@ fi
 # In addition you may want to add the SYS_NICE capability, in order for ntpd to be able to modify its priority.
 ntpd -s
 
-# Wait until Elasticsearch is online since otherwise Elastalert will fail.
+# Elastalert configuration:
+if [ ! -f ${ELASTALERT_CONFIG} ]; then
+    cp "${ELASTALERT_HOME}/config.yaml.example" "${ELASTALERT_CONFIG}" && \
+
+    # Set the rule directory in the Elastalert config file to external rules directory.
+    sed -i -e"s|rules_folder: [[:print:]]*|rules_folder: ${RULES_DIRECTORY}|g" "${ELASTALERT_CONFIG}"
+    # Set the Elasticsearch host that Elastalert is to query.
+    sed -i -e"s|es_host: [[:print:]]*|es_host: ${ELASTICSEARCH_HOST}|g" "${ELASTALERT_CONFIG}"
+    # Set the port used by Elasticsearch at the above address.
+    sed -i -e"s|es_port: [0-9]*|es_port: ${ELASTICSEARCH_PORT}|g" "${ELASTALERT_CONFIG}"
+    # Set the user name used to authenticate with Elasticsearch.
+    sed -i -e"s|#es_username: [[:print:]]*|es_username: ${ELASTICSEARCH_USER}|g" "${ELASTALERT_CONFIG}"
+    # Set the password used to authenticate with Elasticsearch.
+    sed -i -e"s|#es_password: [[:print:]]*|es_password: ${ELASTICSEARCH_PASSWORD}|g" "${ELASTALERT_CONFIG}"
+    # Set the writeback index used with elastalert.
+    sed -i -e"s|writeback_index: [[:print:]]*|writeback_index: ${ELASTALERT_INDEX}|g" "${ELASTALERT_CONFIG}"
+fi
+
+# Elastalert Supervisor configuration:
+if [ ! -f ${ELASTALERT_SUPERVISOR_CONF} ]; then
+    cp "${ELASTALERT_HOME}/supervisord.conf.example" "${ELASTALERT_SUPERVISOR_CONF}" && \
+
+    # Redirect Supervisor log output to a file in the designated logs directory.
+    sed -i -e"s|logfile=.*log|logfile=${LOG_DIR}/elastalert_supervisord.log|g" "${ELASTALERT_SUPERVISOR_CONF}"
+    # Redirect Supervisor stderr output to a file in the designated logs directory.
+    sed -i -e"s|stderr_logfile=.*log|stderr_logfile=${LOG_DIR}/elastalert_stderr.log|g" "${ELASTALERT_SUPERVISOR_CONF}"
+    # Modify the start-command.
+    sed -i -e"s|python elastalert.py|elastalert --config ${ELASTALERT_CONFIG}|g" "${ELASTALERT_SUPERVISOR_CONF}"
+fi
+
+# Set authentication if needed
 if [ -n "$ELASTICSEARCH_USER" ] && [ -n "$ELASTICSEARCH_PASSWORD" ]; then
     WGET_AUTH="$ELASTICSEARCH_USER:$ELASTICSEARCH_PASSWORD@"
 else
     WGET_AUTH=""
 fi
+
+# Wait until Elasticsearch is online since otherwise Elastalert will fail.
 while ! wget -q -T 3 -O - "${WGET_SCHEMA}${WGET_AUTH}${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}" 2>/dev/null
 do
-	echo "Waiting for Elasticsearch..."
-	sleep 1
+    echo "Waiting for Elasticsearch..."
+    sleep 1
 done
 sleep 5
 
 # Check if the Elastalert index exists in Elasticsearch and create it if it does not.
-if ! wget -q -T 3 -O - "${WGET_SCHEMA}${WGET_AUTH}${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/elastalert_status" 2>/dev/null
+if ! wget -q -T 3 -O - "${WGET_SCHEMA}${WGET_AUTH}${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}/${ELASTALERT_INDEX}" 2>/dev/null
 then
     echo "Creating Elastalert index in Elasticsearch..."
-    elastalert-create-index ${CREATE_EA_OPTIONS} --host "${ELASTICSEARCH_HOST}" --port "${ELASTICSEARCH_PORT}" --config "${ELASTALERT_CONFIG}" --index elastalert_status --old-index ""
+    elastalert-create-index ${CREATE_EA_OPTIONS} \
+        --host "${ELASTICSEARCH_HOST}" \
+        --port "${ELASTICSEARCH_PORT}" \
+        --config "${ELASTALERT_CONFIG}" \
+        --index "${ELASTALERT_INDEX}" \
+        --old-index ""
 else
     echo "Elastalert index already exists in Elasticsearch."
 fi

--- a/start-elastalert.sh
+++ b/start-elastalert.sh
@@ -4,11 +4,11 @@ set -e
 
 # Set schema and elastalert options
 case "${ELASTICSEARCH_TLS}:${ELASTICSEARCH_TLS_VERIFY}" in
-    true:true)
+    True:True)
         WGET_SCHEMA='https://'
         CREATE_EA_OPTIONS='--ssl --verify-certs'
     ;;
-    true:false)
+    True:False)
         WGET_SCHEMA='https://'
         CREATE_EA_OPTIONS='--ssl --no-verify-certs'
     ;;
@@ -19,7 +19,7 @@ case "${ELASTICSEARCH_TLS}:${ELASTICSEARCH_TLS_VERIFY}" in
 esac
 
 # Set the timezone.
-if [ "$SET_CONTAINER_TIMEZONE" = "true" ]; then
+if [ "$SET_CONTAINER_TIMEZONE" = "True" ]; then
     cp /usr/share/zoneinfo/${CONTAINER_TIMEZONE} /etc/localtime && \
     echo "${CONTAINER_TIMEZONE}" >  /etc/timezone && \
     echo "Container timezone set to: $CONTAINER_TIMEZONE"


### PR DESCRIPTION
Current image can't be configured properly to use an external elasticsearch cluster or allow a different name for the Elastalert index. This PR tries to resolve these issues.

- Improve docker image rebuild time if the startup script is modified

- Alteration of the configuration is done in the startup script

  Updating the configuration files during build fixes them in place
  making it impossible to configure using env vars.
  No alternations will be made if the files already exist.

- Minor formatting and documentation updates