### PR TITLE
Fix TLS connection problem

### DIFF
--- a/start-elastalert.sh
+++ b/start-elastalert.sh
@@ -69,6 +69,9 @@ if [ ! -f ${ELASTALERT_CONFIG} ]; then
     fi
     # Set the writeback index used with elastalert.
     sed -i -e"s|writeback_index: [[:print:]]*|writeback_index: ${ELASTALERT_INDEX}|g" "${ELASTALERT_CONFIG}"
+    # Set the TLS connection to communicate with Elasticsearch.
+    sed -i -e"s|#use_ssl: [[:print:]]*|use_ssl: ${ELASTICSEARCH_TLS}|g" "${ELASTALERT_CONFIG}"
+    sed -i -e"s|#verify_certs: [[:print:]]*|verify_certs: ${ELASTICSEARCH_TLS_VERIFY}|g" "${ELASTALERT_CONFIG}"
 fi
 
 # Elastalert Supervisor configuration:


### PR DESCRIPTION
This is commit is to fix connection error when connecting to Elasticsearch endpoint that uses TLS. Previous container did not have proper config file for TLS connection and it returned "Connection aborted, Bad StatusLine" error. That was because use_ssl and verify_certs config variables were not handled by start-elastalert.sh script.